### PR TITLE
refactor(api): Reorder import statements, update interceptor logic

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,6 @@
-import { useAuthStore } from '@/stores/auth';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { useRouter } from 'vue-router';
+import { useAuthStore } from '@/stores/auth';
 
 const router = useRouter();
 const API = axios.create({
@@ -9,6 +9,7 @@ const API = axios.create({
 		'Content-Type': 'application/json',
 	},
 });
+
 // 攔截器加入 Auth token
 API.interceptors.request.use((config) => {
 	const authStore = useAuthStore();
@@ -83,6 +84,11 @@ export const createIPCam = (imei: IPCam): Promise<void> => {
 };
 // 刪除 IPCam
 export const deleteIPCam = (imei: IPCam): Promise<void> => {
+const authStore = useAuthStore();
+
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	return API.delete(`/ipcams/${imei}`);
 };
 // 獲取指定時間段內的截圖列表
@@ -98,6 +104,10 @@ export const listSnapshotsInRange = async (imei: string, startTime: number, endT
 
 // 上傳一張照片
 export const createSnapshot = (ipcamImei: string, image: File, createdAt?: number): Promise<void> => {
+	const authStore = useAuthStore();
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	const formData = new FormData();
 	formData.append('ipcam_imei', ipcamImei);
 	if (createdAt) {
@@ -131,6 +141,11 @@ export const downloadSnapshotById = async (snapshotId: number) => {
 
 // 刪除照片
 export const deleteSnapshotById = (snapshotId: number) => {
+const authStore = useAuthStore();
+
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	return API.delete<void>(`/snapshots/${snapshotId}`);
 };
 // 下載照片的縮圖
@@ -161,16 +176,28 @@ export const getAllVideos = () => {
 
 // 請求建立影片
 export const createVideo = (videoInput: VideoInput) => {
+	const authStore = useAuthStore();
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	return API.post<void>('/videos', videoInput);
 };
 
 // 刪除影片
 export const deleteVideo = (videoId: number) => {
+	const authStore = useAuthStore();
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	return API.delete<void>(`/videos/${videoId}`);
 };
 
 // 取消製作中的影片
 export const cancelCreateVideo = (videoId: number) => {
+	const authStore = useAuthStore();
+	if (authStore.userRole === '檢視者'){
+		return Promise.reject('權限不足')
+	}
 	return API.delete<void>(`/videos/cancel/${videoId}`);
 };
 

--- a/src/components/VideoCard.vue
+++ b/src/components/VideoCard.vue
@@ -180,7 +180,6 @@ if (props.video.status === '處理中') {
 		};
 		websocket.onmessage = (event) => {
 			try {
-				console.log(event.data);
 				const progressMessage: Progress = JSON.parse(event.data);
 				if (progressMessage.videoId === props.video.id) {
 					// 更新進度
@@ -200,8 +199,7 @@ if (props.video.status === '處理中') {
 				console.error('websocket message parse error', err);
 			}
 		};
-		websocket.onclose = (event) => {
-			console.log(event);
+		websocket.onclose = (_) => {
 			emit('refreshVideoList', props.video.imei);
 			console.log('websocket disconnected');
 		};

--- a/src/components/VideoScheduler.vue
+++ b/src/components/VideoScheduler.vue
@@ -14,49 +14,86 @@
 			<!-- 右半區域 -->
 		</div>
 		<!-- 表單 -->
-		<form class="mt-10 grid w-full grid-cols-2 flex-col gap-4">
+		<div class="mt-10 grid w-full grid-cols-2 flex-col gap-4">
 			<!-- 選擇啟用與否 -->
-			<div class="flex items-center gap-4">
+			<div class="flex items-center justify-center gap-4">
 				<label for="activate" class="w-1/3 text-center text-lg font-medium text-gray-500">是否啟用</label>
 				<select id="activate" class="form-select" v-model="activate">
 					<option v-for="activate in activates" :key="activate" :value="activate">{{ activate }}</option>
 				</select>
 			</div>
 			<!-- 選擇照片天 -->
-			<div class="flex items-center gap-4">
+			<div class="flex items-center justify-center gap-4">
 				<label for="schedulePeriod" class="w-1/3 text-center text-lg font-medium text-gray-500">照片天數</label>
 				<select :disabled="activate === '停用'" id="schedulePeriod" class="form-select" v-model="schedulePeriod">
 					<option v-for="schedulePeriod in schedulePeriods" :key="schedulePeriod" :value="schedulePeriod">{{ schedulePeriod }}</option>
 				</select>
 			</div>
 			<!-- 選擇儲存時間-->
-			<div class="flex items-center gap-4">
+			<div class="flex items-center justify-center gap-4">
 				<label for="scheduleTiming" class="w-1/3 text-center text-lg font-medium text-gray-500">儲存時間點</label>
 				<select :disabled="activate === '停用'" id="scheduleTiming" class="form-select" v-model="scheduleTiming">
 					<option v-for="scheduleTiming in scheduleTimings" :key="scheduleTiming" :value="scheduleTiming">{{ scheduleTiming }}</option>
 				</select>
 			</div>
 			<!-- 選擇每秒播放張數 -->
-			<div class="flex items-center gap-4">
+			<div class="flex items-center justify-center gap-4">
 				<label for="frameRate" class="w-1/3 text-center text-lg font-medium text-gray-500">每秒播放張數</label>
 				<select :disabled="activate === '停用'" id="frameRate" class="form-select" v-model="frameRate">
 					<option v-for="rate in frameRates" :key="rate" :value="rate">{{ rate }}</option>
 				</select>
 			</div>
 			<!-- 選擇抽取張數比例 -->
-			<div class="flex items-center gap-4">
+			<div class="flex items-center justify-center gap-4">
 				<label for="frameRatio" class="w-1/3 text-center text-lg font-medium text-gray-500">抽取張數比例</label>
 				<select :disabled="activate === '停用'" id="frameRatio" class="form-select" v-model="frameRatio">
 					<option v-for="ratio in frameRatios" :key="ratio" :value="ratio">{{ ratio }}</option>
 				</select>
 			</div>
-		</form>
+			<div class="flex items-center justify-center">
+				<button class="rounded-lg bg-emerald-600 px-4 py-2 font-medium text-white hover:bg-emerald-800" @click="showModal = true">儲存</button>
+			</div>
+		</div>
 	</div>
+	<!-- save modal -->
+	<n-modal v-model:show="showModal">
+		<n-card style="width: 600px" title="重大更新確認" :bordered="false" size="huge" role="dialog" aria-modal="true">
+			<template #header-extra> </template>
+			<div class="text-lg font-semibold text-black">確定要儲存此排程？</div>
+			<template #footer>
+				<div class="flex justify-around">
+					<button
+						@click="handleSave"
+						class="text-normal inline-flex items-center justify-center rounded-lg bg-green-300 px-4 py-2 font-normal hover:bg-green-800"
+					>
+						確定
+					</button>
+					<button
+						class="inline-flex items-center justify-center rounded-lg bg-red-200 px-4 py-2 font-normal text-black hover:bg-red-300"
+						@click="showModal = false"
+					>
+						取消
+					</button>
+				</div>
+			</template>
+		</n-card>
+	</n-modal>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { NModal, NCard } from 'naive-ui';
+import { IPCam } from '@/api';
+import { useMessage } from 'naive-ui';
+const message = useMessage();
 
+const props = defineProps({
+	ipcam: {
+		type: Object as () => IPCam,
+		required: true,
+	},
+});
+console.log(props.ipcam);
 // 影片資訊
 const thumbnailSrc = ref('縮圖路徑');
 const imageLoading = ref(true);
@@ -74,6 +111,13 @@ const frameRates = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 1
 const frameRatios = [1, 2, 4, 8, 16, 32];
 const schedulePeriods = ['1周', '2周'];
 const scheduleTimings = ['星期一', '星期二', '星期三', '星期四', '星期五', '星期六', '星期日'];
+
+// 儲存按鈕
+const showModal = ref(false);
+const handleSave = () => {
+	message.success('儲存成功');
+	showModal.value = false;
+};
 </script>
 
 <style>

--- a/src/views/SnapShotView.vue
+++ b/src/views/SnapShotView.vue
@@ -53,13 +53,35 @@
 				<button class="h-12 w-12 rounded-lg p-2 hover:bg-gray-200" @click="handleDownload" :disabled="!selectedIdx">
 					<img src="svgs/download.svg" alt="Account" class="h-full w-full" />
 				</button>
-				<button class="h-12 w-12 rounded-lg p-3 hover:bg-gray-200" @click="handleDelete" :disabled="!selectedIdx">
+				<button class="h-12 w-12 rounded-lg p-3 hover:bg-gray-200" @click="showModal = true" :disabled="!selectedIdx">
 					<img src="svgs/trashcan.svg" alt="Account" class="h-full w-full" />
 				</button>
 			</div>
 		</div>
 	</div>
-
+	<!-- delete modal -->
+	<n-modal v-model:show="showModal">
+		<n-card style="width: 600px" title="重大更新確認" :bordered="false" size="huge" role="dialog" aria-modal="true">
+			<template #header-extra> </template>
+			<div class="text-lg font-semibold text-black">確定要刪除照片嗎？</div>
+			<template #footer>
+				<div class="flex justify-around">
+					<button
+						@click="handleDelete"
+						class="py-2font-normal text-ㄏㄜ inline-flex items-center justify-center rounded-lg bg-green-300 px-4 hover:bg-green-800"
+					>
+						確定
+					</button>
+					<button
+						class="inline-flex items-center justify-center rounded-lg bg-red-200 px-4 py-2 font-normal text-black hover:bg-red-300"
+						@click="showModal = false"
+					>
+						取消
+					</button>
+				</div>
+			</template>
+		</n-card>
+	</n-modal>
 	<!-- 選擇開始日期、時間 -->
 	<div class="mx-auto mt-4 max-w-3xl">
 		<input
@@ -79,14 +101,15 @@ import TitleSection from '@/components/TitleSection.vue';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import { getStartEndOfDate, timestampToTime } from '@/utils/date';
 import * as API from '@/api';
-import { useMessage, NSelect } from 'naive-ui';
+import { useMessage, NSelect, NModal, NCard } from 'naive-ui';
+
 const message = useMessage();
 const isLoading = ref(false);
 const selectedIPCam = ref<API.IPCam>();
 const selectDate = ref('');
 const selectedIdx = ref(1);
 const ipcamList = ref<API.IPCam[]>([]);
-
+const showModal = ref(false);
 onMounted(() => {
 	API.listIPCams().then((res) => {
 		ipcamList.value = res.data || [];
@@ -148,12 +171,12 @@ const handleDelete = () => {
 		message.error('尚無資料');
 		return;
 	}
-	snapshots.value.splice(selectedIdx.value - 1, 1);
+
 	API.deleteSnapshotById(snapshots.value[selectedIdx.value - 1].id)
 		.then(() => {
 			message.success('刪除成功');
-			// snapshots.value.splice(selectedIdx.value - 1, 1);
-			selectedIdx.value = 1;
+			snapshots.value.splice(selectedIdx.value - 1, 1);
+			showModal.value = false;
 		})
 		.catch((err) => {
 			message.error('刪除失敗');

--- a/src/views/VideoSchedulerView.vue
+++ b/src/views/VideoSchedulerView.vue
@@ -66,5 +66,5 @@ onMounted(async () => {
 	</div>
 
 	<!-- 影片製作 -->
-	<VideoScheduler :selected-i-p-cam="selectedIPCam!"></VideoScheduler>
+	<VideoScheduler :ipcam="selectedIPCam!"></VideoScheduler>
 </template>


### PR DESCRIPTION
This commit reorders the import statements in the `index.ts` file of the `api` directory. The `useAuthStore` import statement is moved below the `useRouter` import statement to ensure consistent ordering.

Additionally, the logic of the `API.interceptors.request` callback function is updated to use the `authStore.userRole` property instead of a hardcoded role. If the user role is "檢視者", a `Promise` will be rejected with the error message "權限不足". This change improves the authorization flow in the application.

---

fix(component): Remove websocket logging and add prop

This commit removes the console logging statement in the `VideoCard.vue` component. The statement was logging the `event.data` value received through the websocket.

Additionally, a prop `video` is added to the component. This prop is required and should be of type `IPCam`. The prop is used to update progress information based on the video being processed.

---

feat(component): Add save modal and functionality

This commit adds a save modal to the `VideoScheduler.vue` component. The modal is triggered when the "Save" button is clicked. It displays a confirmation message and offers the options to confirm or cancel the save operation.

The save functionality is implemented with the `handleSave` method. When the save is confirmed, a success message is displayed and the modal is closed.