### PR TITLE
feat: Add IconSpinner component

### DIFF
--- a/src/components/icons/IconSpinner.vue
+++ b/src/components/icons/IconSpinner.vue
@@ -1,0 +1,10 @@
+<template>
+	<svg class="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+		<path
+			class="opacity-75"
+			fill="currentColor"
+			d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+		></path>
+		<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+	</svg>
+</template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -92,12 +92,15 @@ onMounted(async () => {
 	}
 	isLoading.value = false;
 });
+const refreshed = ref(false);
 const refreshVideoList = async (ipcam: string) => {
 	message.info('更新中...');
+	refreshed.value = false;
 	setTimeout(async () => {
 		const allVideos = (await getVideoList()) || [];
 		videoList.value = allVideos.filter((video) => video.imei === ipcam);
 		message.success('更新成功');
+		refreshed.value = true;
 	}, 2000);
 };
 // 選擇的狀態
@@ -242,6 +245,7 @@ const handleDeleteIPCam = () => {
 				@refresh-video-list="(ipcam) => refreshVideoList(ipcam)"
 				@update-video-status="(videoId, status) => updateStatus(videoId, status)"
 				v-for="video in filteredVideoList"
+				:refreshed="refreshed"
 				:key="video.id"
 				:video="video"
 				:color="statusList.find((statusInfo) => statusInfo.statusName === video.status)?.textColor || 'text-gray-300'"


### PR DESCRIPTION
This commit adds a new component called IconSpinner.vue, which contains the SVG code for a spinning icon. The SVG consists of a circular path with an opacity of 75% and a smaller circle with an opacity of 25%. This component is used in VideoCard.vue.

refactor: Update delete button in VideoCard.vue

This commit updates the delete button in VideoCard.vue. Instead of just showing a trash icon, it now shows an IconSpinner component when the video is being deleted. The IconSpinner component is only shown when the "deleting" flag is true and the "refreshed" flag is false. Additionally, when the video deletion is unsuccessful, the "deleting" flag is set back to false.

refactor: Update handleDeleteVideo function in VideoCard.vue

This commit updates the handleDeleteVideo function in VideoCard.vue. It sets the "deleting" flag to true before calling the API to delete the video. If the deletion is successful, the modal is closed and a success message is shown. If the deletion fails, an error message is shown and the "deleting" flag is set back to false.

refactor: Update refreshVideoList function in HomeView.vue

This commit updates the refreshVideoList function in HomeView.vue. When refreshing the video list, a loading message is shown and a delay of 2 seconds is introduced. After the delay, the video list is updated with the filtered videos and a success message is shown. The "refreshed" flag is set to true when the video list is updated.

refactor: Pass refreshed prop to VideoCard component in HomeView.vue

This commit updates the VideoCard component in HomeView.vue. It adds the "refreshed" prop to the VideoCard component, which is used to determine whether the delete button should show the IconSpinner component or not. The prop is passed down from the parent component.