### PR TITLE
refactor(api): create OnlyAdminCanDelete permission function

### DIFF
--- a/src/api/permission.ts
+++ b/src/api/permission.ts
@@ -1,0 +1,8 @@
+import { useAuthStore } from '@/stores/auth';
+export const OnlyAdminCanDelete = () => {
+	const authStore = useAuthStore();
+	if (authStore.userRole !== '管理員') {
+		return false;
+	}
+	return true;
+};

--- a/src/components/VideoCard.vue
+++ b/src/components/VideoCard.vue
@@ -201,23 +201,21 @@ if (props.video.status === '處理中') {
 					progress.remain = progressMessage.remain;
 				}
 				if (progressMessage.progress === 100 && progressMessage.type === '下載中') {
-					emit('refreshVideoList', props.video.imei);
 				}
 				if (progressMessage.progress === 100 && progressMessage.type === '製作中') {
-					emit('refreshVideoList', props.video.imei);
 					websocket.close();
 				}
 			} catch (err: unknown) {
-				emit('refreshVideoList', props.video.imei);
+				emit('refreshVideoList', props.video.imei, 2000);
 				console.error('websocket message parse error', err);
 			}
 		};
 		websocket.onclose = (_) => {
-			emit('refreshVideoList', props.video.imei);
+			emit('refreshVideoList', props.video.imei, 2000);
 			console.log('websocket disconnected');
 		};
 		websocket.onerror = (event) => {
-			emit('refreshVideoList', props.video.imei);
+			emit('refreshVideoList', props.video.imei, 2000);
 			console.error(event);
 		};
 	} catch (err: unknown) {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,12 +1,12 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import { UserMeta } from '@/api';
+import { UserMeta, UserRole } from '@/api';
 export const useAuthStore = defineStore(
 	'auth',
 	() => {
 		const userId = ref<number>();
 		const userName = ref<string>();
-		const userRole = ref<string>();
+		const userRole = ref<UserRole>();
 		const userAccount = ref<string>();
 		const token = ref<string>();
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -93,15 +93,21 @@ onMounted(async () => {
 	isLoading.value = false;
 });
 const refreshed = ref(false);
-const refreshVideoList = async (ipcam: string) => {
-	message.info('更新中...');
+const refreshVideoList = async (ipcam: string, interval: number = 0) => {
 	refreshed.value = false;
-	setTimeout(async () => {
-		const allVideos = (await getVideoList()) || [];
-		videoList.value = allVideos.filter((video) => video.imei === ipcam);
-		message.success('更新成功');
-		refreshed.value = true;
-	}, 2000);
+	isLoading.value = true;
+	if (interval > 0) {
+		setTimeout(async () => {
+			const allVideos = (await getVideoList()) || [];
+			videoList.value = allVideos.filter((video) => video.imei === ipcam);
+			refreshed.value = true;
+		}, interval);
+		return;
+	}
+	const allVideos = (await getVideoList()) || [];
+	videoList.value = allVideos.filter((video) => video.imei === ipcam);
+	refreshed.value = true;
+	isLoading.value = false;
 };
 // 選擇的狀態
 const selectedStatus = ref('');

--- a/src/views/SnapShotView.vue
+++ b/src/views/SnapShotView.vue
@@ -40,16 +40,16 @@
 	</div>
 	<!-- 圖片 -->
 	<div class="mx-auto mt-8 max-w-3xl overflow-hidden rounded-lg bg-white shadow-lg">
-		<a v-if="snapshots.length > 0" :href="snapshots[selectedIdx - 1].path" target="_blank">
-			<img class="h-96 w-full object-cover" :src="snapshots[selectedIdx - 1].path" alt="縮時截圖載入中" />
+		<a v-if="snapshots.length > 0" :href="snapshots[selectedIdx].path" target="_blank">
+			<img class="h-96 w-full object-cover" :src="snapshots[selectedIdx].path" alt="縮時截圖載入中" />
 		</a>
 		<n-spin v-else :size="20" />
 
 		<div v-else class="h-96 w-full animate-pulse bg-slate-200"></div>
 		<div class="flex items-center justify-between p-4">
 			<div class="flex flex-col">
-				<h2 class="mb-2 text-xl font-semibold">{{ snapshots.length > 0 ? timestampToTime(snapshots[selectedIdx - 1].created_at) : '尚無資料' }}</h2>
-				<p class="text-gray-500">{{ snapshots.length > 0 ? snapshots[selectedIdx - 1].ipcam_imei : 'no data' }}</p>
+				<h2 class="mb-2 text-xl font-semibold">{{ snapshots.length > 0 ? timestampToTime(snapshots[selectedIdx].created_at) : '尚無資料' }}</h2>
+				<p class="text-gray-500">{{ snapshots.length > 0 ? snapshots[selectedIdx].ipcam_imei : 'no data' }}</p>
 			</div>
 			<div class="flex items-center justify-center gap-4">
 				<button class="h-12 w-12 rounded-lg p-2 hover:bg-gray-200" @click="handleDownload" :disabled="!selectedIdx">
@@ -70,7 +70,7 @@
 				<div class="flex justify-around">
 					<button
 						@click="handleDelete"
-						class="py-2font-normal text-ㄏㄜ inline-flex items-center justify-center rounded-lg bg-green-300 px-4 hover:bg-green-800"
+						class="inline-flex items-center justify-center rounded-lg bg-green-300 px-4 py-2 font-normal text-black hover:bg-green-800"
 					>
 						確定
 					</button>
@@ -90,8 +90,8 @@
 			v-model="selectedIdx"
 			id="steps-range"
 			type="range"
-			min="1"
-			:max="snapshots.length"
+			min="0"
+			:max="snapshots.length - 1"
 			step="1"
 			class="h-4 w-full cursor-pointer rounded-sm"
 		/>
@@ -109,7 +109,7 @@ const message = useMessage();
 const isLoading = ref(false);
 const selectedIPCam = ref<API.IPCam>();
 const selectDate = ref('');
-const selectedIdx = ref(1);
+const selectedIdx = ref(0);
 
 const ipcamList = ref<API.IPCam[]>([]);
 const showModal = ref(false);
@@ -125,7 +125,7 @@ watch(selectedIPCam, async (newIPCam, oldIPCam) => {
 	if (newIPCam !== oldIPCam) {
 		// 清空snapshots, selectedIdx, selectDate
 		snapshots.value = [];
-		selectedIdx.value = 1;
+		selectedIdx.value = 0;
 		selectDate.value = '';
 	}
 });
@@ -174,8 +174,8 @@ const handleDownload = () => {
 		message.error('尚無資料');
 		return;
 	}
-	a.href = snapshots.value[selectedIdx.value - 1].path;
-	a.download = `${timestampToTime(snapshots.value[selectedIdx.value - 1].created_at)}.png`;
+	a.href = snapshots.value[selectedIdx.value].path;
+	a.download = `${timestampToTime(snapshots.value[selectedIdx.value].created_at)}.png`;
 	a.click();
 };
 const handleDelete = () => {
@@ -184,10 +184,14 @@ const handleDelete = () => {
 		return;
 	}
 
-	API.deleteSnapshotById(snapshots.value[selectedIdx.value - 1].id)
+	API.deleteSnapshotById(snapshots.value[selectedIdx.value].id)
 		.then(() => {
 			message.success('刪除成功');
-			snapshots.value.splice(selectedIdx.value - 1, 1);
+			snapshots.value.splice(selectedIdx.value, 1);
+			// 更新selectedIdx
+			if (selectedIdx.value === snapshots.value.length) {
+				selectedIdx.value = snapshots.value.length - 1;
+			}
 			showModal.value = false;
 		})
 		.catch((err) => {


### PR DESCRIPTION
- Creates a new file `permission.ts` to export the `OnlyAdminCanDelete` function.
- The `OnlyAdminCanDelete` function checks if the user's role is '管理員' and only allows them to delete certain resources.
- This function can be used in multiple API endpoints for permission validation.

Co-authored-by: WaterSo0910 <jacky950141@gmail.com>