### PR TITLE
feat: Increase refresh delay in VideoCard component

### DIFF
--- a/src/components/VideoCard.vue
+++ b/src/components/VideoCard.vue
@@ -201,7 +201,7 @@ if (props.video.status === '處理中') {
 					progress.remain = progressMessage.remain;
 				}
 				if (progressMessage.progress === 100 && progressMessage.type === '下載中') {
-					emit('refreshVideoList', props.video.imei, 2000);
+					emit('refreshVideoList', props.video.imei, 4000);
 				}
 				if (progressMessage.progress === 100 && progressMessage.type === '製作中') {
 					websocket.close();

--- a/src/views/SnapShotView.vue
+++ b/src/views/SnapShotView.vue
@@ -160,7 +160,8 @@ const handleDate = () => {
 	}
 
 	downloadNum.value = 0;
-
+	totalNum.value = 0;
+	downloadProgress.value = 0;
 	API.listSnapshotsInRange(selectedIPCam.value!, start.getTime() / 1000, end.getTime() / 1000)
 		.then((res) => {
 			if (!res || res.length === 0) {


### PR DESCRIPTION
The refresh delay for the video list in the VideoCard component has been increased to 4000 milliseconds. This change ensures that the video list is refreshed with a longer delay after the download process completes.

fix: Reset values in SnapShotView component

The values for the total number of snapshots, the number of snapshots downloaded, and the download progress have been reset to zero in the SnapShotView component. This fix ensures that the correct values are displayed when listing snapshots within a specific time range.